### PR TITLE
Fix flickering/unusable items bug

### DIFF
--- a/QuickSlots/Patches/Inventory_Awake_Patch.cs
+++ b/QuickSlots/Patches/Inventory_Awake_Patch.cs
@@ -17,13 +17,6 @@ namespace QuickSlotsMod.Patches
         {
             int slotCount = Mod.config.SlotCount;
 
-            string[] newSlotNames = new string[slotCount];
-            for (int i = 0; i < slotCount; ++i)
-            {
-                newSlotNames[i] = "QuickSlot" + i;
-            }
-            typeof(QuickSlots).GetField("slotNames", BindingFlags.Static | BindingFlags.NonPublic).SetValue(null, newSlotNames);
-
             Player player = __instance.GetComponent<Player>();
             QuickSlots newQuickSlots = new QuickSlots(__instance.gameObject, __instance.toolSocket, __instance.cameraSocket, __instance, player.rightHandSlot, slotCount);
 

--- a/QuickSlots/Patches/QuickSlots_SlotNames_Patch.cs
+++ b/QuickSlots/Patches/QuickSlots_SlotNames_Patch.cs
@@ -1,0 +1,76 @@
+﻿using HarmonyLib;
+using QuickSlotsMod.Utility;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using Logger = UnityEngine.Logger;
+
+namespace QuickSlotsMod.Patches
+{
+
+    /***
+     * The QuickSlots.slotNames variable was set in the Inventory_Awake_Patch, but it sometimes resets back to the hardcoded length of 5. When this
+     * happens it causes index out of range exceptions when you select the added quick slots in game and eventually causes strange flickering and makes items unusable.
+     * I couldn't determine what triggers this, but we can transpile the few methods that call the "slotNames" variable and load our own to avoid it.
+     */
+    [HarmonyPatch(typeof(QuickSlots))]
+    [HarmonyPatch("Update")]
+    class QuickSlots_SlotNames_Patch
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (var i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Ldsfld)
+                {
+                    codes[i].operand = AccessTools.Field(typeof(NamesUtil), "slotNames");
+                    Logger.Log("Transpiled Update method with new slotnames.");
+                    break;
+                }
+            }
+            return codes;
+        }
+    }
+
+    [HarmonyPatch(typeof(QuickSlots))]
+    [HarmonyPatch("SelectInternal")]
+    class QuickSlots_SelectInternal_Patch
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (var i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Ldsfld && codes[i + 1].opcode == OpCodes.Ldarg_1)
+                {
+                    codes[i].operand = AccessTools.Field(typeof(NamesUtil), "slotNames");
+                    Logger.Log("Transpiled SelectInternal method with new slotnames.");
+                    break;
+                }
+            }
+            return codes;
+        }
+    }
+
+    [HarmonyPatch(typeof(QuickSlots))]
+    [HarmonyPatch("DeselectInternal")]
+    class QuickSlots_DeselectInternal_Patch
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            for (var i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Ldsfld && codes[i + 1].opcode == OpCodes.Ldloc_0)
+                {
+                    codes[i].operand = AccessTools.Field(typeof(NamesUtil), "slotNames");
+                    Logger.Log("Transpiled DeselectInternal method with new slotnames.");
+                    break;
+                }
+            }
+            return codes;
+        }
+    }
+}

--- a/QuickSlots/QuickSlotsMod.csproj
+++ b/QuickSlots/QuickSlotsMod.csproj
@@ -92,9 +92,11 @@
     <Compile Include="Logger.cs" />
     <Compile Include="Mod.cs" />
     <Compile Include="Patches\Inventory_Awake_Patch.cs" />
+    <Compile Include="Patches\QuickSlots_SlotNames_Patch.cs" />
     <Compile Include="Patches\uGUI_QuickSlots_Init_Patch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\ImageUtils.cs" />
+    <Compile Include="Utility\NamesUtil.cs" />
     <Compile Include="Utility\SimpleJSON.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/QuickSlots/Utility/NamesUtil.cs
+++ b/QuickSlots/Utility/NamesUtil.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace QuickSlotsMod.Utility
+{
+    class NamesUtil
+    {
+        public static string[] slotNames = Enumerable.Range(1, Mod.config.SlotCount).Select(n => "QuickSlot" + n).ToArray();
+    }
+}


### PR DESCRIPTION
Flickering is caused when the slotNames variable gets reset somehow, maybe after a long time it unloads the QuickSlots class? Instead of overwriting it we can transpile the methods that call it and provide our own variable instead.

AFAIK this should work on Subnautica too but I haven't tested it.